### PR TITLE
Add universe-template

### DIFF
--- a/install-all
+++ b/install-all
@@ -1,2 +1,2 @@
 #!/bin/sh
-cabal install ./base ./instances/base ./instances/containers ./instances/extended ./instances/reverse ./instances/trans ./top
+cabal install ./base ./instances/base ./instances/containers ./instances/extended ./instances/reverse ./instances/trans ./template ./top

--- a/template/Data/Universe/TH.hs
+++ b/template/Data/Universe/TH.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE AutoDeriveTypeable #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+module Data.Universe.TH (deriveSomeUniverse) where
+
+import Control.Monad
+import Data.Foldable
+import Data.Some
+import Data.Universe.Class
+import Language.Haskell.TH
+
+-- | Given a type name, @N@, create an @instance Universe (Some N)@.  @N@ should represent a type of kind @k -> *@.
+deriveSomeUniverse :: Name -> Q [Dec]
+deriveSomeUniverse n =
+  [d| instance Universe (Some $(conT n)) where
+        universe = $(universeForData n)
+    |]
+
+universeForData :: Name -> Q Exp
+universeForData n = reify n >>= \case
+  TyConI (DataD _ _ _ _ cons _) -> (varE 'concat `appE`) $ fmap (ListE . concat) $ mapM universeForCon cons
+  a -> fail $ "universeForData: Unmatched 'Info': " <> show a
+  where
+    -- Enumerate all values for the constructor by recursively invoking 'universe'
+    --TODO: Should we use a traversal order other than what we get from the list
+    --monad's 'join'?
+    conWithArgs name numArgs = [| This <$> $(foldl' (\x y -> [| $x <*> $y |]) [| pure $(conE name) |] $ replicate numArgs [| universe |]) |]
+    universeForCon = \case
+      GadtC names bts _ -> forM names $ \name -> conWithArgs name $ length bts
+      NormalC name bts -> fmap (:[]) $ conWithArgs name $ length bts
+      ForallC _ _ con -> universeForCon con
+      a -> fail $ "universeForData: Unmatched 'Dec': " <> show a

--- a/template/LICENSE
+++ b/template/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2018, Daniel Wagner
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Daniel Wagner nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+! This software is provided by the copyright holders and contributors
+! "as is" and any express or implied warranties, including, but not
+! limited to, the implied warranties of merchantability and fitness for
+! a particular purpose are disclaimed. In no event shall the copyright
+! owner or contributors be liable for any direct, indirect, incidental,
+! special, exemplary, or consequential damages (including, but not
+! limited to, procurement of substitute goods or services; loss of use,
+! data, or profits; or business interruption) however caused and on any
+! theory of liability, whether in contract, strict liability, or tort
+! (including negligence or otherwise) arising in any way out of the use
+! of this software, even if advised of the possibility of such damage.

--- a/template/test/test.hs
+++ b/template/test/test.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE RankNTypes #-}
+import Data.Universe.TH
+
+import Data.Some
+import Data.GADT.Show.TH
+import Data.Universe.Class
+import Data.Universe.Instances.Base ()
+
+data TestGadt a where
+  A, B :: TestGadt Int
+  C :: Bool -> TestGadt Int
+  D :: forall b. TestGadt b
+  E :: Bool -> Either Bool () -> TestGadt a
+  F :: Some TestGadt2 -> TestGadt a
+
+data TestGadt2 a where
+  T2I :: TestGadt2 Int
+  T2S :: TestGadt2 String
+
+deriveGShow ''TestGadt
+deriveGShow ''TestGadt2
+
+deriveSomeUniverse ''TestGadt
+deriveSomeUniverse ''TestGadt2
+
+main :: IO ()
+main = print (universe :: [Some TestGadt])

--- a/template/universe-template.cabal
+++ b/template/universe-template.cabal
@@ -26,6 +26,7 @@ library
   build-depends:       base                    >=4   && <5  ,
                        dependent-sum           ==0.4.*      ,
                        template-haskell        ==2.13.*     ,
+                       th-extras               ==0.0.*      ,
                        universe-base           >=1.0 && <1.2,
                        universe-instances-base >=1.0 && <1.2
   default-language:    Haskell2010

--- a/template/universe-template.cabal
+++ b/template/universe-template.cabal
@@ -1,0 +1,45 @@
+name:                universe-template
+version:             1.1
+synopsis:            Template Haskell functions to derive Universe instances
+homepage:            https://github.com/dmwit/universe
+license:             BSD3
+license-file:        LICENSE
+author:              Daniel Wagner and Obsidian Systems LLC
+maintainer:          me@dmwit.com
+copyright:           Daniel Wagner and Obsidian Systems LLC 2018
+category:            Data
+build-type:          Simple
+cabal-version:       >=1.10
+tested-with:
+  GHC==8.4.3
+
+source-repository head
+    type:            git
+    location:        https://github.com/dmwit/universe
+source-repository this
+    type:            git
+    location:        https://github.com/dmwit/universe
+    tag:             1.1
+
+library
+  exposed-modules:     Data.Universe.TH
+  build-depends:       base                    >=4   && <5  ,
+                       dependent-sum           ==0.4.*      ,
+                       template-haskell        ==2.13.*     ,
+                       universe-base           >=1.0 && <1.2,
+                       universe-instances-base >=1.0 && <1.2
+  default-language:    Haskell2010
+  other-extensions:    FlexibleContexts
+  ghc-options:         -Wall
+
+test-suite test
+  type: exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is: test.hs
+  build-depends: base,
+                 universe-base,
+                 universe-template,
+                 universe-instances-base,
+                 dependent-sum-template,
+                 dependent-sum
+  ghc-options: -Wall


### PR DESCRIPTION
I added a template here to derive instances for `Universe (Some F)` ([`Some` being from `dependent-sum:Data.Some`](http://hackage.haskell.org/package/dependent-sum-0.4/docs/Data-Some.html#t:Some)), where `F :: k -> *`.  As far as I know, it's not possible to do this with generics.

I'm happy to keep this as a separate library if you prefer, but I figured I'd offer it here first.