### PR TITLE
Add pragma for GHC 8.6

### DIFF
--- a/instances/extended/Data/Universe/Instances/Extended.hs
+++ b/instances/extended/Data/Universe/Instances/Extended.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE UndecidableInstances #-}
 module Data.Universe.Instances.Extended (
 	-- | Instances for 'Universe' and 'Finite' for function-like functors and the empty type.
 	Universe(..), Finite(..)


### PR DESCRIPTION
GHC 8.6 made `UndecidableInstances` necessary for some of the extended instances.